### PR TITLE
Update to  `FMT``8.1.1` and improve tests.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,36 @@
+:: cmd
 
-cmake -G"NMake Makefiles" ^
-  -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
-  -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
-  -DCMAKE_BUILD_TYPE:STRING=Release ^
-  -DBUILD_SHARED_LIBS:BOOL=TRUE ^
-  -DFMT_TEST:BOOL=OFF ^
-  -DFMT_DOC:BOOL=OFF ^
-  -DFMT_INSTALL:BOOL=ON ^
-  .
+
+:: Isolate the build.
+mkdir Build
+cd Build
 if errorlevel 1 exit 1
 
-nmake
+
+:: Generate the build files.
+cmake .. -G"Ninja" %CMAKE_ARGS% ^
+      -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DFMT_TEST=OFF ^
+      -DFMT_DOC=OFF ^
+      -DFMT_INSTALL=ON ^
+      -DCMAKE_BUILD_TYPE=Release
+
+
+:: Build.
+ninja
 if errorlevel 1 exit 1
 
-nmake install
+
+:: Perforem tests.
+ninja test
 if errorlevel 1 exit 1
+
+
+:: Build and install.
+ninja install
+if errorlevel 1 exit 1
+
+
+:: Error free exit.
+exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,13 +1,30 @@
+#!/bin/bash
 
-cmake ${CMAKE_ARGS} \
-  -DCMAKE_PREFIX_PATH:PATH=${PREFIX} \
-  -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} \
-  -DCMAKE_INSTALL_LIBDIR=lib \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_SHARED_LIBS=TRUE \
-  -DFMT_TEST=OFF \
-  -DFMT_DOC=OFF \
-  -DFMT_INSTALL=ON \
-  .
 
-make -j${CPU_COUNT} install
+# Isolate the build.
+mkdir -p Build
+cd Build || exit 1
+
+
+# Generate the build files.
+cmake .. -G"Ninja" ${CMAKE_ARGS} \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DBUILD_SHARED_LIBS=TRUE \
+      -DFMT_TEST=ON \
+      -DFMT_DOC=OFF \
+      -DFMT_INSTALL=ON \
+      -DCMAKE_BUILD_TYPE=Release
+
+
+# Build.
+ninja || exit 1
+
+
+# Perform tests.
+ninja test || exit 1
+
+
+# Install.
+ninja install || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "fmt" %}
-{% set version = "7.1.3" %}
-{% set sha256 = "5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc" %}
+{% set version = "8.1.1" %}
+{% set sha256 = "3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346" %}
+{% set build_number = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: {{ build_number }}
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage('fmt', max_pin='x') }}
@@ -20,7 +21,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
-    - make  # [unix]
+    - ninja
 
 test:
   commands:
@@ -44,8 +45,9 @@ about:
   description: |
     {fmt} is an open-source formatting library for C++.
     It can be used as a safe and fast alternative to (s)printf and iostreams.
-  doc_url: https://fmt.dev/latest/
   dev_url: https://github.com/fmtlib/fmt
+  doc_url: https://fmt.dev/latest/
+  doc_src_url: https://github.com/fmtlib/fmt/tree/master/doc
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
 Changes

Changes:
- Update version from `7.1.3` to `8.1.1`.
- Prefer ninja to make/nmake.
- Enable author's testing.

# Review Information

## Source

https://github.com/fmtlib/fmt/tree/8.1.1


## Upstream Changes

https://github.com/fmtlib/fmt/releases

There are significant changes since `7.1.3`. Mamba seems to need
something here, so let's take it.


## Issues

https://github.com/fmtlib/fmt/issues

Mostly enhacements.


## Pins and Requireds

https://github.com/fmtlib/fmt/blob/8.1.1/CMakeLists.txt
C++ library requiring only system libraries.


## Testing

Author's testing is enabled and evaluated.


# Clossing Comments

I see no reason not to take this update.

<!--
Please add any other relevant info below:
-->
