### PR TITLE
fmt 9.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,11 @@
 :: cmd
+echo "Building %PKG_NAME%."
 
 
 :: Isolate the build.
-mkdir Build
-cd Build
-if errorlevel 1 exit 1
+mkdir Build-%PKG_NAME%
+cd Build-%PKG_NAME%
+if errorlevel 1 exit /b 1
 
 
 :: Generate the build files.
@@ -12,11 +13,11 @@ echo "Generating the build files."
 cmake .. -G"Ninja" %CMAKE_ARGS% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_BUILD_TYPE=Release ^
       -DFMT_TEST=ON ^
       -DFMT_DOC=OFF ^
       -DBUILD_SHARED_LIBS=TRUE ^
-      -DFMT_INSTALL=ON ^
-      -DCMAKE_BUILD_TYPE=Release
+      -DFMT_INSTALL=ON
 
 
 :: Build.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+echo "Building ${PKG_NAME}."
 
 
 # Isolate the build.
-mkdir -p Build
-cd Build || exit 1
+mkdir -p Build-${PKG_NAME}
+cd Build-${PKG_NAME} || exit 1
 
 
 # Generate the build files.
@@ -11,12 +12,12 @@ echo "Generating the build files."
 cmake .. -G"Ninja" ${CMAKE_ARGS} \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DBUILD_SHARED_LIBS=TRUE \
       -DFMT_TEST=ON \
       -DFMT_DOC=OFF \
-      -DFMT_INSTALL=ON \
-      -DCMAKE_BUILD_TYPE=Release
+      -DFMT_INSTALL=ON
 
 
 # Build.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/fmtlib/fmt/archive/{{ version }}.tar.gz
+  url: https://github.com/fmtlib/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -25,16 +25,16 @@ requirements:
 
 test:
   commands:
-    - test -d ${PREFIX}/include/fmt  # [unix]
-    - test -f ${PREFIX}/include/fmt/core.h  # [unix]
-    - test -f ${PREFIX}/include/fmt/format.h  # [unix]
+    - test -d ${PREFIX}/include/fmt                     # [unix]
+    - test -f ${PREFIX}/include/fmt/core.h              # [unix]
+    - test -f ${PREFIX}/include/fmt/format.h            # [unix]
     - test -f ${PREFIX}/lib/cmake/fmt/fmt-config.cmake  # [unix]
-    - test -f ${PREFIX}/lib/libfmt.so  # [linux]
-    - test -f ${PREFIX}/lib/libfmt.dylib  # [osx]
-    - if exist %LIBRARY_PREFIX%\include\fmt\core.h (exit 0) else (exit 1)  # [win]
-    - if exist %LIBRARY_PREFIX%\include\fmt\format.h (exit 0) else (exit 1)  # [win]
+    - test -f ${PREFIX}/lib/libfmt.so                   # [linux]
+    - test -f ${PREFIX}/lib/libfmt.dylib                # [osx]
+    - if exist %LIBRARY_PREFIX%\include\fmt\core.h (exit 0) else (exit 1)          # [win]
+    - if exist %LIBRARY_PREFIX%\include\fmt\format.h (exit 0) else (exit 1)        # [win]
     - if exist %LIBRARY_PREFIX%\lib\cmake\fmt-config.cmake (exit 0) else (exit 1)  # [win]
-    - if exist %LIBRARY_PREFIX%\bin\fmt.dll (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\bin\fmt.dll (exit 0) else (exit 1)                 # [win]
 
 about:
   home: https://fmt.dev/latest/
@@ -47,7 +47,6 @@ about:
     It can be used as a safe and fast alternative to (s)printf and iostreams.
   dev_url: https://github.com/fmtlib/fmt
   doc_url: https://fmt.dev/latest/
-  doc_src_url: https://github.com/fmtlib/fmt/tree/master/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "fmt" %}
-{% set version = "8.1.1" %}
-{% set sha256 = "3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346" %}
-{% set build_number = "1" %}
+{% set version = "9.1.0" %}
+{% set sha256 = "5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2" %}
+{% set build_number = "0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Changelog: https://github.com/fmtlib/fmt/blob/9.1.0/ChangeLog.rst
License: https://github.com/fmtlib/fmt/blob/9.1.0/LICENSE.rst
Requirements: https://github.com/fmtlib/fmt/blob/9.1.0/CMakeLists.txt

Actions:
1. Enhance readability: add comments to `build.sh` and `bld.bat`, fix exits
2. Remove `doc_src_url`

Notes:

- The downstream package `libmamba 1.3.0` requires `styled` https://fmt.dev/9.1.0/api.html#_CPPv4I0EN3fmt6styledEN6detail10styled_argI14remove_cvref_tI1TEEERK1T10text_style missing in the current fmt 8.1.1
```
/miniconda3/conda-bld/mamba-split_1675758565658/work/libmamba/src/core/output.cpp:125:41: error: no member named 'styled' in namespace 'fmt'
                                   fmt::styled(row[j].s, row[j].style),
                                   ~~~~~^
/miniconda3/conda-bld/mamba-split_1675758565658/work/libmamba/src/core/output.cpp:132:41: error: no member named 'styled' in namespace 'fmt'
                                   fmt::styled(row[j].s, row[j].style),
                                   ~~~~~^
```
- For building `libmamba 1.3.0` conda-forge uses `fmt 9.1.0` and `spglog 1.11.0`, see https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=652819&view=logs&j=ced5d8de-8227-5f3f-33a1-45cf1592c45a&t=f7bcb349-6dca-53ba-d88d-1d9963e119ba
- packages that depend on `fmt`: 
  - `libmamba`, `libmambapy`, and `spdlog` have pinning `fmt >=8.1.1,<9.0a0`,
  - `omniscidb`, `omniscidb-common`, `omniscidbe`, and `pyomniscidbe` have pinning `fmt >=7.1.3,<8.0a0` https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=fmt